### PR TITLE
Input file updates

### DIFF
--- a/rollo/constraints.py
+++ b/rollo/constraints.py
@@ -119,6 +119,10 @@ class Constraints(object):
                     not_constrained = False
             if not_constrained:
                 new_pop.append(ind)
+        if len(new_pop) == 0:
+            raise Exception(
+                "All individuals were constrained. Run with larger population size or reconsider your constraint choice. "
+            )
         final_pop = [self.toolbox.clone(ind) for ind in new_pop]
         while len(final_pop) < len(pop):
             final_pop.append(self.toolbox.clone(random.choice(new_pop)))

--- a/rollo/evaluation.py
+++ b/rollo/evaluation.py
@@ -63,7 +63,12 @@ class Evaluation:
             pass
         return
 
-    def eval_fn_generator(self, control_dict, output_dict, input_evaluators):
+    def eval_fn_generator(
+            self,
+            control_dict,
+            output_dict,
+            input_evaluators,
+            gens):
         """Returns a function that accepts a DEAP individual and returns a
         tuple of output values listed in outputs
 
@@ -105,8 +110,9 @@ class Evaluation:
             self.rank_time = time.time()
             control_vars = self.name_ind(ind, control_dict, input_evaluators)
             output_vals = [None] * len(output_dict)
+            order_of_solvers = self.solver_order(input_evaluators)
 
-            for solver in input_evaluators:
+            for solver in order_of_solvers:
                 # path name for solver's run
                 path = solver + "_" + str(ind.gen) + "_" + str(ind.num)
                 # render jinja-ed input script
@@ -125,11 +131,20 @@ class Evaluation:
                 output_vals = self.get_output_vals(
                     output_vals, solver, output_dict, control_vars, path
                 )
-                if not input_evaluators[solver]["keep_files"]:
+                if input_evaluators[solver]["keep_files"] == "none":
                     shutil.rmtree(path)
+                elif input_evaluators[solver]["keep_files"] == "only_final":
+                    if ind.gen < gens - 1:
+                        shutil.rmtree(path)
             return tuple(output_vals)
 
         return eval_function
+
+    def solver_order(self, input_evaluators):
+        order = [None] * len(input_evaluators)
+        for solver in input_evaluators:
+            order[input_evaluators[solver]["order"]] = solver
+        return order
 
     def get_output_vals(
             self,

--- a/rollo/executor.py
+++ b/rollo/executor.py
@@ -193,9 +193,9 @@ class Executor(object):
                 input_script=solver_dict["input_script"],
                 output_script=output_script,
             )
+        gens = input_dict["algorithm"]["generations"]
         evaluator_fn = evaluator.eval_fn_generator(
-            control_dict, output_dict, input_dict["evaluators"]
-        )
+            control_dict, output_dict, input_dict["evaluators"], gens)
         return evaluator_fn
 
     def load_toolbox(

--- a/rollo/input_validation.py
+++ b/rollo/input_validation.py
@@ -38,11 +38,12 @@ class InputValidation:
         for solver in input_dict["evaluators"]:
             input_evaluators[solver] = input_dict["evaluators"][solver]
             input_evaluators[solver] = self.default_check(
-                input_evaluators[solver], "keep_files", True
+                input_evaluators[solver], "keep_files", "all"
             )
         input_algorithm = input_dict["algorithm"]
         input_algorithm = self.default_check(
             input_algorithm, "objective", "min")
+        input_algorithm = self.default_check(input_algorithm, "weight", [1.0])
         input_algorithm = self.default_check(input_algorithm, "pop_size", 60)
         input_algorithm = self.default_check(
             input_algorithm, "generations", 10)
@@ -174,6 +175,10 @@ class InputValidation:
                     "type": "array",
                     "items": {"type": "string"},
                 },
+                "weight": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                },
                 "optimized_variable": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -195,6 +200,7 @@ class InputValidation:
             [
                 "parallel",
                 "objective",
+                "weight",
                 "pop_size",
                 "generations",
                 "mutation_probability",
@@ -448,6 +454,7 @@ class InputValidation:
             schema_evaluators["properties"][evaluator] = {
                 "type": "object",
                 "properties": {
+                    "order": {"type": "number"},
                     "input_script": {"type": "string"},
                     "inputs": {
                         "type": "array",
@@ -458,16 +465,21 @@ class InputValidation:
                         "items": {"type": "string"},
                     },
                     "output_script": {"type": "string"},
-                    "keep_files": {"type": "boolean"},
+                    "keep_files": {"type": "string"},
                 },
             }
         validate(instance=input_evaluators, schema=schema_evaluators)
         for evaluator in input_evaluators:
             self.validate_correct_keys(
                 input_evaluators[evaluator],
-                ["input_script", "inputs", "outputs"],
+                ["input_script", "inputs", "outputs", "order"],
                 ["output_script", "keep_files"],
                 "evaluator: " + evaluator,
+            )
+            self.validate_in_list(
+                input_evaluators[evaluator]["keep_files"],
+                ["none", "all", "only_final"],
+                "keep_files",
             )
             # check if outputs are in predefined outputs or inputs, and if not
             # output_script must be defined

--- a/rollo/toolbox_generator.py
+++ b/rollo/toolbox_generator.py
@@ -38,11 +38,12 @@ class ToolboxGenerator(object):
         """
 
         weight_list = []
-        for obj in input_algorithm["objective"]:
+        for obj, wt in zip(input_algorithm["objective"],
+                           input_algorithm["weight"]):
             if obj == "min":
-                weight_list.append(-1.0)
+                weight_list.append(-wt)
             elif obj == "max":
-                weight_list.append(+1.0)
+                weight_list.append(+wt)
         creator.create("obj", base.Fitness, weights=tuple(weight_list))
         creator.create("Ind", list, fitness=creator.obj)
         toolbox = base.Toolbox()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -36,9 +36,10 @@ def test_eval_fn_generator():
             }
         ),
         input_evaluators={
-            "openmc": {"keep_files": True},
-            "moltres": {"keep_files": True},
+            "openmc": {"keep_files": True, "order": 0},
+            "moltres": {"keep_files": True, "order": 1},
         },
+        gens=2,
     )
 
     creator.create("obj", base.Fitness, weights=(-1.0,))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -21,6 +21,7 @@ test_input_dict = {
     },
     "evaluators": {
         "openmc": {
+            "order": 0,
             "input_script": "input_test_eval_fn_generator_openmc_template.py",
             "inputs": ["packing_fraction", "polynomial_triso"],
             "outputs": ["packing_fraction", "keff", "num_batches"],
@@ -28,6 +29,7 @@ test_input_dict = {
             "keep_files": True,
         },
         "moltres": {
+            "order": 1,
             "input_script": "input_test_render_jinja_template_python.py",
             "inputs": [],
             "outputs": ["max_temp"],
@@ -38,6 +40,7 @@ test_input_dict = {
     "constraints": {"keff": {"operator": [">"], "constrained_val": [1]}},
     "algorithm": {
         "objective": ["max", "min"],
+        "weight": [1.0, 1.0],
         "optimized_variable": ["keff", "packing_fraction"],
         "pop_size": 100,
         "generations": 10,

--- a/tests/test_toolbox_generator.py
+++ b/tests/test_toolbox_generator.py
@@ -20,12 +20,14 @@ test_input_dict = {
     },
     "evaluators": {
         "openmc": {
+            "order": 0,
             "input_script": "input_test_eval_fn_generator_openmc_template.py",
             "inputs": ["packing_fraction", "polynomial_triso"],
             "outputs": ["packing_fraction", "keff", "num_batches"],
             "output_script": "input_test_eval_fn_generator_openmc_output.py",
         },
         "moltres": {
+            "order": 1,
             "input_script": "input_test_render_jinja_template_python.py",
             "inputs": [],
             "outputs": ["max_temp"],
@@ -35,6 +37,7 @@ test_input_dict = {
     "constraints": {"keff": {"operator": ">", "constrained_val": 1}},
     "algorithm": {
         "objective": ["max", "min"],
+        "weight": [1.0, 1.0],
         "optimized_variable": ["keff", "packing_fraction"],
         "pop_size": 100,
         "generations": 10,


### PR DESCRIPTION
In this PR, I added 2 new input parameters to ROLLO's input file and updated one input parameter. 

Added parameters 
`weight`: list. This parameter was added into the algorithm section of the input file, and indicates the weight for each objective as a list. 
`order`: int. This parameter was added into the evaluators section of the input file, and indicates the order of software evaluations. It is indexed by 0 

Updated parameters 
`keep_files`: string. This parameter used to be a True, False Boolean. I updated it to be a string input. Accepted strings are `none`, `only_final`, `all`. 

This PR is intended to be stacked with #24. This PR will be easier to review once #24's pep8 updates have been merged into main. 